### PR TITLE
Reduced container size other optimizations

### DIFF
--- a/000-jobe.conf
+++ b/000-jobe.conf
@@ -1,0 +1,28 @@
+<VirtualHost *:80>
+    ServerAdmin root@localhost
+    DocumentRoot /var/www/html
+
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+    ErrorDocument 400 "400 HTTP_BAD_REQUEST"
+    ErrorDocument 401 "401 HTTP_UNAUTHORIZED"
+    ErrorDocument 403 "403 HTTP_FORBIDDEN"
+    ErrorDocument 404 "404 HTTP_NOT_FOUND"
+    ErrorDocument 405 "405 HTTP_METHOD_NOT_ALLOWED"
+    ErrorDocument 408 "408 HTTP_REQUEST_TIME_OUT"
+    ErrorDocument 410 "410 HTTP_GONE"
+    ErrorDocument 411 "411 HTTP_LENGTH_REQUIRED"
+    ErrorDocument 412 "412 HTTP_PRECONDITION_FAILED"
+    ErrorDocument 413 "413 HTTP_REQUEST_ENTITY_TOO_LARGE"
+    ErrorDocument 414 "414 HTTP_REQUEST_URI_TOO_LARGE"
+    ErrorDocument 415 "415 HTTP_UNSUPPORTED_MEDIA_TYPE"
+    ErrorDocument 500 "500 HTTP_INTERNAL_SERVER_ERROR"
+    ErrorDocument 501 "501 HTTP_NOT_IMPLEMENTED"
+    ErrorDocument 502 "502 HTTP_BAD_GATEWAY"
+    ErrorDocument 503 "503 HTTP_SERVICE_UNAVAILABLE"
+    ErrorDocument 506 "506 HTTP_VARIANT_ALSO_VARIES"
+
+</VirtualHost>
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,5 +73,9 @@ RUN ln -snf /usr/share/zoneinfo/"$TZ" /etc/localtime && \
 # Expose apache
 EXPOSE 80
 
+# Healthcheck, minimaltest.py should complete within 2 seconds
+HEALTHCHECK --interval=5m --timeout=2s \
+    CMD python3 /var/www/html/jobe/minimaltest.py || exit 1
+
 # Start apache
 CMD ["/usr/sbin/apache2ctl", "-D", "FOREGROUND"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,13 @@
 # Jobe-in-a-box: a Dockerised Jobe server (see https://github.com/trampgeek/jobe)
 # With thanks to David Bowes (d.h.bowes@herts.ac.uk) who did all the hard work
 # on this originally.
-# Version 2.1, 31 January 2019.
-# Version 2.2, 15 October 2019 added cleaning && logging.
 
 FROM ubuntu:18.04
 
-LABEL maintainer="richard.lobb@canterbury.ac.nz"
+LABEL maintainers="richard.lobb@canterbury.ac.nz,j.hoedjes@hva.nl"
 ARG TZ=Pacific/Auckland
 ARG ROOTPASS=jobeisfab
-
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
-    apt-get update && apt-get install -yq tzdata \
-      apache2 php libapache2-mod-php php-cli php-mbstring octave nodejs \
-      build-essential python3 php-cli fp-compiler \
-      openjdk-11-jdk python3-pip pylint3 sqlite3 git acl unzip sudo && \
-    pylint3 --reports=no --score=n --generate-rcfile > /etc/pylintrc && \
-    apt-get -y autoremove && \
-    apt-get -y autoclean && \
-    apt-get -y clean && \
-    ln -sf /proc/self/fd/1 /var/log/apache2/access.log && \
-    ln -sf /proc/self/fd/1 /var/log/apache2/error.log
-
-# Manually set up the apache environment variables
+# Set up the (apache) environment variables
 ENV APACHE_RUN_USER www-data
 ENV APACHE_RUN_GROUP www-data
 ENV APACHE_LOG_DIR /var/log/apache2
@@ -30,16 +15,51 @@ ENV APACHE_LOCK_DIR /var/lock/apache2
 ENV APACHE_PID_FILE /var/run/apache2.pid
 ENV LANG C.UTF-8
 
-# Now get jobe and install it
-RUN cd /var/www/html && sudo git clone https://github.com/trampgeek/jobe.git && \
-    cd /var/www/html/jobe && apache2ctl start && ./install
+# Set timezone
+# Install extra packages
+# Redirect apache logs to stdout
+# Configure apache
+# Setup root password
+# Get and install jobe and clean up
+RUN ln -snf /usr/share/zoneinfo/"$TZ" /etc/localtime && \
+    echo "$TZ" > /etc/timezone && \
+    apt-get update && \
+    apt-get --no-install-recommends install -yq tzdata \
+      apache2 \
+      php \
+      libapache2-mod-php \
+      php-cli \
+      php-mbstring \
+      octave nodejs \
+      build-essential \
+      python3 \
+      php-cli \
+      fp-compiler \
+      openjdk-11-jdk \
+      python3-pip \
+      pylint3 \
+      sqlite3 \
+      git \
+      acl \
+      unzip \
+      sudo && \
+    pylint3 --reports=no --score=n --generate-rcfile > /etc/pylintrc && \
+    ln -sf /proc/self/fd/1 /var/log/apache2/access.log && \
+    ln -sf /proc/self/fd/1 /var/log/apache2/error.log && \
+    sed -i -e "s/export LANG=C/export LANG=$LANG/" /etc/apache2/envvars && \
+    sed -i -e "1 i ServerName localhost" /etc/apache2/apache2.conf && \
+    mkdir -p /var/crash && \
+    echo "root:$ROOTPASS" | chpasswd && \
+    git clone https://github.com/trampgeek/jobe.git /var/www/html/jobe && \
+    apache2ctl start && \
+    cd /var/www/html/jobe && ./install && \
+    chown -R www-data:www-data /var/www/html && \
+    apt-get -y autoremove && \
+    apt-get -y autoclean && \
+    apt-get -y clean
 
 # Expose apache
 EXPOSE 80
 
-RUN echo "root:$ROOTPASS" | chpasswd && \
-    chown -R www-data /var/www/html && \
-    sed -i -e "s/export LANG=C/export LANG=$LANG/" /etc/apache2/envvars && \
-    sed -i -e "1 i ServerName localhost" /etc/apache2/apache2.conf
-
+# Start apache
 CMD ["/usr/sbin/apache2ctl", "-D", "FOREGROUND"]

--- a/README.md
+++ b/README.md
@@ -16,4 +16,8 @@ Or with a different timezone:
 
     docker build . -t test/jobeinabox --build-arg TZ="Europe/Amsterdam"
 
+And with a different root password, and please do since the source is open:
+
+    docker build . -t test/jobeinabox --build-arg TZ="Europe/Amsterdam" --build-arg ROOTPASS="complicated_password"
+
 Instructions for using the image are on [DockerHub](https://hub.docker.com/r/trampgeek/jobeinabox/)

--- a/README.md
+++ b/README.md
@@ -2,11 +2,18 @@
 
 The [Moodle CodeRunner question type plugin](https://moodle.org/plugins/qtype_coderunner) requires a [Jobe server](https://github.com/trampgeek) on which to run student-submitted jobs. [JobeInABox](https://hub.docker.com/r/trampgeek/jobeinabox/) is a Docker image that provides a basic Jobe server that runs all the standard languages but does not have a mysql server installed so cannot use API-key access. For normal use, that's not a problem - API-key access is relevant only to Jobe servers delivering services to multiple clients.
 
-If you're looking for the ready to run Docker image itself, you'll find it [in the DockerHub repo](https://hub.docker.com/r/trampgeek/jobeinabox/). This GitHub repository is relevant only if you wish to build your own
-customised Docker image.
+If you're looking for the ready to run Docker image itself, you'll find it [in the DockerHub repo](https://hub.docker.com/r/trampgeek/jobeinabox/). This GitHub repository is relevant only if you wish to build your own customised Docker image.
 
-To build a docker image, make sure you have docker and docker-comose installed. Then pull this repo, cd into the jobeinabox directory and edit Dockerfile to suit your own needs. Then simply build the image with the command
+To build a docker image with docker-compose, make sure you have docker and docker-compose installed. Then pull this repo, cd into the jobeinabox directory and edit Dockerfile to suit your own needs. Then simply build the image with the command.
 
     docker-compose build
-    
+
+To build a docker image with the docker command, make sure you have docker installed. Then pull this repo, cd into jobeinabox directory and edit Dockerfile to suit your own needs. Then simply build the image with the command.
+
+    docker build . -t test/jobeinabox
+
+Or with a different timezone:
+
+    docker build . -t test/jobeinabox --build-arg TZ="Europe/Amsterdam"
+
 Instructions for using the image are on [DockerHub](https://hub.docker.com/r/trampgeek/jobeinabox/)

--- a/instructions
+++ b/instructions
@@ -1,3 +1,0 @@
-# To build your own JobeInABox, edit docker-compose.yml to your own needs.
-# Then build with the command
-docker-compose build


### PR DESCRIPTION
Hi, i further optimized the container:

* Reduced container size by ~500MB with the `--no-install-recommends` apt-get option
* Hide Apache and PHP version*
* Merged 3 RUN statements into 1
* Added a `HEALTHCHECK` based on `minimaltest.py`
* Added /var/crash directory (I saw it referenced in the sudoers file (after jobe installation)
* Merged information file into the README.md and added instruction for building the container only with the docker command.

---

* Successfully tested it with `testsubmit.py`
* Note: building will fail in the future when PHP is updated to 7.3, see line 61 in the dockerfile

\* Not very effective since the source is here, open, but hey.. 



