### PR TITLE
Add license file - same as Jobe

### DIFF
--- a/license.txt
+++ b/license.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2019 David Bowes & Richard Lobb
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.


### PR DESCRIPTION
Hi Richard, We are thinking of switching the JobeInABox at the Open University, and we are the sort of organisation that likes to have the Is dotted and the Ts crossed, so we would be happier if it was clear what licence JobeInABox was shared under.

Obivously, you may want to make your own decision, but in case it helps, here is a pull request with the same licence as Jobe itself (I just edited the copyright info.)

Thanks, Tim.