### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,9 +45,8 @@ RUN ln -snf /usr/share/zoneinfo/"$TZ" /etc/localtime && \
         libapache2-mod-php \
         nodejs \
         octave \
-        openjdk-14-jdk \
+        openjdk-16-jdk \
         php \
-        php-cli \
         php-cli \
         php-mbstring \
         python3 \


### PR DESCRIPTION
As mentioned off-topic in the issue #8, this fixes the two problems in the Dockerfile:

- Updated openjdk-14-jdk to version openjdk-16-jdk as package for the version 14 has been removed from the latest Ubuntu 20.04.3 apt repository.
- Removed duplicate php-cli entry.