### PR TITLE
Utilize Dockerized jdk over Ubuntu JDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@
 # With thanks to David Bowes (d.h.bowes@lancaster.ac.uk) who did all the hard work
 # on this originally.
 
+# grab openjdk-16 container first, then ubuntu 20.04 base image
+FROM openjdk:16-jdk AS jdk
 FROM docker.io/ubuntu:20.04
 
 # https://github.com/opencontainers/image-spec/blob/master/annotations.md
@@ -19,7 +21,15 @@ ENV APACHE_RUN_GROUP www-data
 ENV APACHE_LOG_DIR /var/log/apache2
 ENV APACHE_LOCK_DIR /var/lock/apache2
 ENV APACHE_PID_FILE /var/run/apache2.pid
+ENV JAVA_HOME /usr/lib/jvm/java-16-openjdk-amd64
 ENV LANG C.UTF-8
+
+# Copy OpenJDK into Ubuntu container and setup via update-alternatives
+COPY --from=jdk /usr/java/openjdk-16 /usr/lib/jvm/java-16-openjdk-amd64
+RUN update-alternatives --install /usr/bin/java java /usr/lib/jvm/java-16-openjdk-amd64/bin/java 20 && \
+    update-alternatives --auto java && \
+    update-alternatives --install /usr/bin/javac javac /usr/lib/jvm/java-16-openjdk-amd64/bin/javac 20 && \
+    update-alternatives --auto javac
 
 # Copy apache virtual host file for later use
 COPY 000-jobe.conf /
@@ -45,7 +55,6 @@ RUN ln -snf /usr/share/zoneinfo/"$TZ" /etc/localtime && \
         libapache2-mod-php \
         nodejs \
         octave \
-        openjdk-16-jdk \
         php \
         php-cli \
         php-mbstring \


### PR DESCRIPTION
This merge creates a multi-layer Docker container for jobeinabox, utilizing the published Docker containers for openjdk and Ubuntu 20.04 LTS.  The openjdk containers are typically patched for security issues much quicker than Ubuntu team patches their packages.  This commit pulls in the latest openjdk:16-jdk image, and places it into the same location that Ubuntu does in the filesystem (/usr/lib/jvm/java-16-openjdk-amd64).  It utilizes the update-alternatives system in Ubuntu to correctly set paths for the java and javac binary.

The end result is that the Java version goes from the Ubuntu 16.0.1 version to the Dockerize openjdk:16-jdk version, which is 16.0.2.