### PR TITLE
Adjust HEALTHCHECK so docker can see the container has started faster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,7 @@ RUN ln -snf /usr/share/zoneinfo/"$TZ" /etc/localtime && \
 EXPOSE 80
 
 # Healthcheck, minimaltest.py should complete within 2 seconds
-HEALTHCHECK --interval=5m --timeout=2s \
+HEALTHCHECK --start-period=30s --start-interval=5s --interval=5m --timeout=2s \
     CMD /usr/bin/python3 /var/www/html/jobe/minimaltest.py || exit 1
 
 # Start apache


### PR DESCRIPTION
Without this docker would thing the container was only in state (health: starting) for 5 minutes, before it went to (healthy), which was not ideal.

The docs --start-interval say "This option requires Docker Engine version 25.0 or later." (https://docs.docker.com/reference/dockerfile/#healthcheck). I don't know if that is an issue? Docker 25 was released in January this year https://docs.docker.com/engine/release-notes/25.0/#2500