### PR TITLE
Feature: API keys configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,28 @@ You can check the performance of the container with the command
 
     docker exec -it jobe /var/www/html/jobe/testsubmit.py --perf
 
+## Using API Keys
+
+You can provid API keys during the image build via the `--secret` option.
+
+The keys can be stored in a separate file, following the format:
+
+```
+'c1425880-2289-4b76-ae29-bcea34997256' => 0,
+'de7970e6-0466-4ce2-a6a4-c1a51363bd03' => 90
+```
+
+You can find more information on API keys in the Jobe documentation.
+
+With the following command the keys stored in a file called `api_keys` in the
+jobeinabox directory are automatically added to `/var/www/html/jobe/app/Config/Jobe.php`
+and the option `$require_api_keys` is set to true.
+
+```
+podman build . -t my/jobeinabox --secret id=api_keys,src=api_keys
+```
+
+If no API keys are provided the configuration remains untouched.
 
 ### Warnings:
 


### PR DESCRIPTION
The API keys can be provided during the image build via the `--secret` option.
The keys can be stored in a separate file, following the format:

```
'c1425880-2289-4b76-ae29-bcea34997256' => 0,
'de7970e6-0466-4ce2-a6a4-c1a51363bd03' => 90
```

With the following command the keys stored in `./api_keys` are automatically added to `Config/Jobe.php` and the option `$require_api_keys` is set to true.

`podman build . -t my/jobeinabox --secret id=api_keys,src=api_keys`

If no API keys are provided the configuration remains untouched.

Following the example from above, this is the configuration with the provided keys:

```
root@c49e624a9c8b:/# head -30 /var/www/html/jobe/app/Config/Jobe.php
<?php

namespace Config;

use CodeIgniter\Config\BaseConfig;

class Jobe extends BaseConfig
{
    /*
    |--------------------------------------------------------------------------
    | Jobe parameters
    |--------------------------------------------------------------------------
    |
    | This config file contains Jobe-server specific constants.
    */

    /**
     * API keys.
     * If $require_api_keys is true, the array $api_keys is a map from api
     * key to allowed rate of requests per hour. A value of 0 means unlimited.
     */
    public bool $require_api_keys = true;
    public array $api_keys = [
        'c1425880-2289-4b76-ae29-bcea34997256' => 0, 'de7970e6-0466-4ce2-a6a4-c1a51363bd03' => 90
    ];

    /*
    | jobe_max_users controls how many jobs can be run by the server at any
    | one time. It *must* agree with the number of users with names jobe01,
    | jobe02, jobe03 etc (which is how the install script will set things up).
```